### PR TITLE
Change clojure command to clj in the example project.

### DIFF
--- a/example/task
+++ b/example/task
@@ -22,7 +22,7 @@ cljs () {
 dev () {
   # Download dependencies first. This prevents clj and shadow-cljs from trying
   # to clone new git dependencies at the same time which causes an error.
-  clojure -Spath > /dev/null
+  clj -Spath > /dev/null
   if which overmind > /dev/null 2>&1 ; then
     overmind start
   else


### PR DESCRIPTION
Users can have a clj binary but not a clojure binary. The clojure binary may also be different, and may not support -Spath.