### PR TITLE
Change task to use bash from environment variable

### DIFF
--- a/resources/biff/project/base/{{dir}}/task
+++ b/resources/biff/project/base/{{dir}}/task
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 for f in config/task.env all-tasks/*; do

--- a/task
+++ b/task
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 cd "$(dirname "${BASH_SOURCE[0]}")"
 


### PR DESCRIPTION
Handy for environments where /bin/bash can't be assumed such as Nixos.