### PR TITLE
Add org.slf4j/slf4j-nop depedency prevent messages when running task dev

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -18,6 +18,8 @@
   nrepl/nrepl {:mvn/version "0.5.3"}
   org.clojure/tools.namespace {:mvn/version "1.0.0"}
   org.postgresql/postgresql {:mvn/version "42.2.12.jre7"}
+  ;; add this because tools.deps.alpha no longer includes it
+  org.slf4j/slf4j-nop {:mvn/version "1.7.25"}
   ovotech/ring-jwt {:mvn/version "1.2.5"}
   ring/ring-core {:mvn/version "1.8.0"}
   ring/ring-defaults {:mvn/version "0.3.2"}


### PR DESCRIPTION
Only an annoyance.
These messages show while running `./task dev` 
```
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
```
Adding the slf4j-nop dependency resolves.