### PR TITLE
clj requires -M to execute clojure.main programs.

### DIFF
--- a/new-project.sh
+++ b/new-project.sh
@@ -1,5 +1,7 @@
 sha="$(git ls-remote https://github.com/jacobobryant/biff.git HEAD | awk '{ print $1 }')"
 deps="{:deps {github-jacobobryant/biff {:git/url \"https://github.com/jacobobryant/biff\" :sha \"$sha\"}}}"
-chkapi=`clj -Sdescribe | grep repl-aliases`
-mopt="" && [[ -n $chkapi ]] && mopt="-M"
+mopt=""
+if clj -Sdescribe | grep -q repl-aliases; then
+  mopt="-M"
+fi
 clj -Sdeps "$deps" "$mopt" -m biff.project

--- a/new-project.sh
+++ b/new-project.sh
@@ -1,3 +1,3 @@
 sha="$(git ls-remote https://github.com/jacobobryant/biff.git HEAD | awk '{ print $1 }')"
 deps="{:deps {github-jacobobryant/biff {:git/url \"https://github.com/jacobobryant/biff\" :sha \"$sha\"}}}"
-clj -Sdeps "$deps" -m biff.project
+clj -Sdeps "$deps" -M -m biff.project

--- a/new-project.sh
+++ b/new-project.sh
@@ -1,3 +1,5 @@
 sha="$(git ls-remote https://github.com/jacobobryant/biff.git HEAD | awk '{ print $1 }')"
 deps="{:deps {github-jacobobryant/biff {:git/url \"https://github.com/jacobobryant/biff\" :sha \"$sha\"}}}"
-clj -Sdeps "$deps" -M -m biff.project
+chkapi=`clj -Sdescribe | grep repl-aliases`
+mopt="" && [[ -n $chkapi ]] && mopt="-M"
+clj -Sdeps "$deps" "$mopt" -m biff.project

--- a/resources/biff/project/base/{{dir}}/all-tasks/10-biff
+++ b/resources/biff/project/base/{{dir}}/all-tasks/10-biff
@@ -39,7 +39,7 @@ dev () {
   fi
   npx onchange -i tailwind.css -- ./task build-css-dev &
   trap 'kill $(jobs -p) 2> /dev/null' EXIT
-  BIFF_ENV=dev clj {% if spa %}-A:cljs {% endif %}"$@" -m $MAIN_NS
+  BIFF_ENV=dev clj -M{% if spa %}:cljs{% endif %} "$@" -m $MAIN_NS
 }
 
 

--- a/resources/biff/project/base/{{dir}}/all-tasks/10-biff
+++ b/resources/biff/project/base/{{dir}}/all-tasks/10-biff
@@ -39,8 +39,10 @@ dev () {
   fi
   npx onchange -i tailwind.css -- ./task build-css-dev &
   trap 'kill $(jobs -p) 2> /dev/null' EXIT
-  chkapi=`clj -Sdescribe | grep repl-aliases`
-  mopt="-A" && [[ -n $chkapi ]] && mopt="-M"
+  mopt="-A"
+  if clj -Sdescribe | grep -q repl-aliases; then
+    mopt="-M"
+  fi
   BIFF_ENV=dev clj $mopt{% if spa %}:cljs{% endif %} "$@" -m $MAIN_NS
 }
 

--- a/resources/biff/project/base/{{dir}}/all-tasks/10-biff
+++ b/resources/biff/project/base/{{dir}}/all-tasks/10-biff
@@ -39,7 +39,9 @@ dev () {
   fi
   npx onchange -i tailwind.css -- ./task build-css-dev &
   trap 'kill $(jobs -p) 2> /dev/null' EXIT
-  BIFF_ENV=dev clj -M{% if spa %}:cljs{% endif %} "$@" -m $MAIN_NS
+  chkapi=`clj -Sdescribe | grep repl-aliases`
+  mopt="-A" && [[ -n $chkapi ]] && mopt="-M"
+  BIFF_ENV=dev clj $mopt{% if spa %}:cljs{% endif %} "$@" -m $MAIN_NS
 }
 
 

--- a/slate/source/index.html.md
+++ b/slate/source/index.html.md
@@ -432,7 +432,7 @@ The default environment is `:prod`. This can be overridden by setting the
 `BIFF_ENV` environment variable:
 
 ```shell
-BIFF_ENV=dev clj -m example.core
+BIFF_ENV=dev clj -M -m example.core
 ```
 
 So this:


### PR DESCRIPTION
As of 1.10.1.672 version:
https://insideclojure.org/2020/09/04/clj-exec/

On the command line suppresses this:
WARNING: When invoking clojure.main, use -M
