### PR TITLE
Fix biff/crop-day returning fn instead of calling

### DIFF
--- a/src/com/biffweb.clj
+++ b/src/com/biffweb.clj
@@ -604,7 +604,7 @@
 (defn crop-day
   "Same as (crop-date \"yyyy-MM-dd\")"
   [date]
-  time/crop-day)
+  (time/crop-day date))
 
 (defn elapsed?
   "Returns true if t2 occurs at least x units after t1.


### PR DESCRIPTION
While poking around the code, I noticed that `biff/crop-day` wasn't actually calling the function it looks like it should be calling. Based on the docstring this looks like a bug rather than intended.