### PR TITLE
Fix two issues with production deployment

### DIFF
--- a/tasks/src/com/biffweb/tasks.clj
+++ b/tasks/src/com/biffweb/tasks.clj
@@ -107,7 +107,7 @@
   []
   (apply clojure "-P" (run-args))
   (shell "sudo" "systemctl" "reset-failed" "app.service")
-  (shell "sudo" "systemctl" "resart" "app"))
+  (shell "sudo" "systemctl" "restart" "app"))
 
 (defn deploy
   "Deploys the app via `git push`.

--- a/tasks/src/com/biffweb/tasks.clj
+++ b/tasks/src/com/biffweb/tasks.clj
@@ -58,7 +58,7 @@
   (io/make-parents "target/resources/_")
   (when (fs/exists? "package.json")
     (shell "npm" "install"))
-  (apply println "clj" (run-args)))
+  (apply shell "clj" (run-args)))
 
 (defn css [& args]
   (apply shell

--- a/tasks/src/com/biffweb/tasks.clj
+++ b/tasks/src/com/biffweb/tasks.clj
@@ -58,7 +58,7 @@
   (io/make-parents "target/resources/_")
   (when (fs/exists? "package.json")
     (shell "npm" "install"))
-  (apply shell "clj" (run-args)))
+  (apply println "clj" (run-args)))
 
 (defn css [& args]
   (apply shell

--- a/tasks/src/com/biffweb/tasks.clj
+++ b/tasks/src/com/biffweb/tasks.clj
@@ -50,7 +50,7 @@
   ["-J-XX:-OmitStackTraceInFastThrow"
    "-M" "-m" (:biff.tasks/main-ns @config)
    "--port" "7888"
-   "--middleware" "[cider.nrepl/cider-middleware refactor-nrepl.middleware/wrap-refactor]"])
+   "--middleware" "[cider.nrepl/cider-middleware,refactor-nrepl.middleware/wrap-refactor]"])
 
 (defn run-cmd
   "Internal. Used by the server to start the app."


### PR DESCRIPTION
See commits for details.

If you'll forgive me for a couple of tangential comments, I'll drop a couple of challenges that I faced in the deployment section of the tutorial here in case you want to investigate or add some detail to the tutorial.

First, I got the following error in the post-receive hook, which I haven't tracked down yet. Here's the output I saw:

```
remote: sudo: a terminal is required to read the password; either use the -S option to read from standard input or configure an askpass helper
remote: sudo: a password is required
remote: Error while executing task: post-receive
```

I ssh'd in to my droplet and manually executed the commands as root, which worked. I _think_ doing that once fixed the issue for future deploys, although I'm not sure. I don't know why it would, but I didn't see the same error when I deployed my most recent change, which was to switch to use this fork instead of the main biff repo. Actually, maybe one of these commits also fixed that issue? Again, I'm not sure.

Second, I have my git configured to use `main` as the default branch instead of `master`. I had to change the `:tasks` -> `:biff.tasks/deploy-from` key in my `config.edn` to `"main:master"` to get it to work. I'm not sure how much you care, but the name of the key doesn't really fit this use case. Perhaps renaming `:biff.tasks/deploy-to` to `:biff.tasks/deploy-to-remote` and `:biff.tasks/deploy-from` to `:biff.tasks/deploy-branch`? Or perhaps a new config key would be more clear to separate source branch and destination branch. That's a design decision that I'll leave in your capable hands.