### PR TITLE
Rename "features" to "plugins" in docs

### DIFF
--- a/docs/01-tutorial/01-new-project.md
+++ b/docs/01-tutorial/01-new-project.md
@@ -86,12 +86,12 @@ let's remove the `com.eelchat.feat.worker` namespace. Remove it from `com.eelcha
              [clojure.java.io :as io]
              [clojure.string :as str]
 ;; ...
- (def features
-   [app/features
-    auth/features
--   home/features
--   worker/features])
-+   home/features])
+ (def plugins
+   [app/plugin
+    auth/plugin
+-   home/plugin
+-   worker/plugin])
++   home/plugin])
 
  (def routes [["" {:middleware [anti-forgery/wrap-anti-forgery
                                 biff/wrap-anti-forgery-websockets
@@ -126,7 +126,7 @@ with a simple `Nothing here yet` message:
      [:.h-6]
      [:div "Nothing here yet."])))
 
-(def features
+(def plugin
   {:routes ["/app" {:middleware [mid/wrap-signed-in]}
             ["" {:get app}]]})
 ```

--- a/docs/01-tutorial/02-landing-page.md
+++ b/docs/01-tutorial/02-landing-page.md
@@ -250,6 +250,6 @@ And do the same in `com.eelchat.feat.app`:
 +     [:div "Thanks for joining the waitlist. "
 +      "We'll let you know when eelchat is ready to use."])))
  
- (def features
+ (def plugin
    {:routes ["/app" {:middleware [mid/wrap-signed-in]}
 ```

--- a/docs/01-tutorial/04-communities.md
+++ b/docs/01-tutorial/04-communities.md
@@ -101,7 +101,7 @@ Head over to `com.eelchat.feat.app` and throw in a "New community" button:
 +    {:status 303
 +     :headers {"location" "/app"}}))
 
- (def features
+ (def plugin
 -  {:routes ["/app" {:middleware [mid/wrap-signed-in]}
 -            ["" {:get app}]]})
 +  {:routes ["" {:middleware [mid/wrap-signed-in]}
@@ -362,7 +362,7 @@ a member already, and if not, show a join button:
 +      {:status 303
 +       :headers {"location" "/app"}})))
  
- (def features
+ (def plugin
    {:routes ["" {:middleware [mid/wrap-signed-in]}
              ["/app"           {:get app}]
              ["/community"     {:post new-community}]

--- a/docs/01-tutorial/05-channels.md
+++ b/docs/01-tutorial/05-channels.md
@@ -111,7 +111,7 @@ Next we'll add a handler so that the button actually does something. We'll also 
 +        {:status 303
 +         :headers {"Location" (str "/community/" (:xt/id community))}}))))
 +
- (def features
+ (def plugin
    {:routes ["" {:middleware [mid/wrap-signed-in]}
              ["/app"           {:get app}]
              ["/community"     {:post new-community}]

--- a/docs/01-tutorial/07-realtime.md
+++ b/docs/01-tutorial/07-realtime.md
@@ -169,7 +169,7 @@ send new messages to all the channel participants:
    (fn [{:keys [biff/db user path-params] :as req}]
      (if-some [community (xt/entity db (parse-uuid (:id path-params)))]
 ;; ...
- (def features
+ (def plugin
    {:routes ["" {:middleware [mid/wrap-signed-in]}
 ;; ...
                ["" {:get channel-page

--- a/docs/01-tutorial/08-inbound-rss.md
+++ b/docs/01-tutorial/08-inbound-rss.md
@@ -255,7 +255,7 @@ contents:
          (map #(assoc-result sys %))
          (mapcat sub-tx))))
 
-(def features
+(def plugin
   {:tasks [{:task #'fetch-rss
             :schedule #(every-n-minutes 5)}]})
 ```
@@ -273,11 +273,11 @@ Then register the new namespace in your app:
              [clojure.java.io :as io]
              [clojure.string :as str]
 ;; ...
- (def features
-   [app/features
-    auth/features
-+   sub/features
-    home/features])
+ (def plugins
+   [app/plugin
+    auth/plugin
++   sub/plugin
+    home/plugin])
 
  (def routes [["" {:middleware [anti-forgery/wrap-anti-forgery
 ```
@@ -380,7 +380,7 @@ Add a `:fetch-rss` queue like so:
 +  (biff/submit-tx sys
 +    (sub-tx (assoc-result sys job))))
 +
- (def features
+ (def plugin
    {:tasks [{:task #'fetch-rss
 -            :schedule #(every-n-minutes 5)}]})
 +            :schedule #(every-n-minutes 5)}]

--- a/docs/02-reference/02-routing.md
+++ b/docs/02-reference/02-routing.md
@@ -16,7 +16,7 @@ Multiple routes:
 
 (defn bar ...)
 
-(def features
+(def plugin
   {:routes [["/foo" {:get foo}]
             ["/bar" {:post bar}]]})
 ```
@@ -28,14 +28,14 @@ Path parameters:
   (println (:token path-params))
   ...)
 
-(def features
+(def plugin
   {:routes [["/click/:token" {:get click}]]})
 ```
 
 Nested routes:
 
 ```clojure
-(def features
+(def plugin
   {:routes [["/auth/"
              ["send" {:post send-token}]
              ["verify/:token" {:get verify-token}]]]})
@@ -51,7 +51,7 @@ With middleware:
       {:status 303
        :headers {"location" "/"}})))
 
-(def features
+(def plugin
   {:routes [["/app" {:middleware [wrap-signed-in]}
              ["" {:get app}]
              ["/set-foo" {:post set-foo}]]]})
@@ -66,7 +66,7 @@ CSRF protection (this is a feature of Biff, not Reitit):
    :headers {"content-type" "application/json"}
    :body params})
 
-(def features
+(def plugin
   {:api-routes [["/echo" {:post echo}]]})
 ```
 

--- a/docs/02-reference/06-htmx.md
+++ b/docs/02-reference/06-htmx.md
@@ -21,7 +21,7 @@ with some text after it's clicked:
 (defn click [request]
   [:div "Earth will now self-destruct"])
 
-(def features
+(def plugin
   {:routes [["/page" {:get page}]
             ["/click" {:post click}]]})
 ```


### PR DESCRIPTION
Noticed a few places in the documentations that referenced the older `(def feature)` naming scheme. Maybe the docs should mention `features == plugins` for existing projects, but I felt the tutorial docs should match the example codebase.