### PR TITLE
Remove trailing slash from XTDB `learn` URL

### DIFF
--- a/docs/02-reference/04-transactions.md
+++ b/docs/02-reference/04-transactions.md
@@ -3,7 +3,7 @@ title: Transactions
 ---
 
 *Biff uses [XTDB](https://xtdb.com/) for the database. It's OK if you haven't used XTDB before,*
-*but you may want to peruse some of the [learning resources](https://xtdb.com/learn/) at least.*
+*but you may want to peruse some of the [learning resources](https://xtdb.com/learn) at least.*
 
 The system map (and by extension, incoming requests) includes a
 `:biff.xtdb/node` key which can be used to submit transactions:


### PR DESCRIPTION
Hail Jacob! I have been pouring over your docs and code and am in love with what you have built. 

I noticed this link was broken; but not very broken. Here are screenshots and their links:
`https://www.xtdb.com/learn/`
![Trailing Slash](https://github.com/jacobobryant/biff/assets/8226466/5e6c91a5-59c4-4b9b-b32b-ed7086ecfc61)

`https://www.xtdb.com/learn`
![No Slash](https://github.com/jacobobryant/biff/assets/8226466/95a79102-7056-481d-90ef-72db9a2ae3a3)

Thanks again for creating and sharing this tool.