### PR TITLE
Clean up trenchman install artifacts

### DIFF
--- a/example/server-setup.sh
+++ b/example/server-setup.sh
@@ -19,9 +19,10 @@ apt-get -y install default-jre rlwrap ufw git snapd
 bash < <(curl -s https://download.clojure.org/install/linux-install-$CLJ_VERSION.sh)
 bash < <(curl -s https://raw.githubusercontent.com/babashka/babashka/master/install)
 wget https://github.com/athos/trenchman/releases/download/v$TRENCH_VERSION/$TRENCH_FILE
-tar -xf $TRENCH_FILE
-rm $TRENCH_FILE
-mv trench /usr/local/bin/
+mkdir .trench_tmp
+tar -xf $TRENCH_FILE --directroy .trench_tmp
+mv .trench_tmp/trench /usr/local/bin/
+rm -rf $TRENCH_FILE .trench_tmp
 
 # Non-root user
 useradd -m app


### PR DESCRIPTION
![Clean up](https://github.com/jacobobryant/biff/assets/8226466/b2b9f155-67e4-4158-9a10-c4ed5dde403b)

Just a small change to consider for the `server-setup.sh` script.

The `trenchman` install step deletes the tarball but leaves a few artifacts:
1. `README.md`
1. `LICENSE` 
1. `CHANGELOG.md`

This PR aims to take the boyscout approach of "Leave no trace". 
1. We make a temp folder. 
1. Extract the tarball to the folder vice  the app root.
1. Copy the file from the temp folder.
1. Delete the tarball and temp folder.
1. Profit???