### PR TITLE
update docstring for com.biffweb/q to clarify handling of non-vector :find values

### DIFF
--- a/src/com/biffweb.clj
+++ b/src/com/biffweb.clj
@@ -616,8 +616,8 @@
   "Convenience wrapper for xtdb.api/q.
 
   If the :find value is not a vector, results will be passed through
-  (map first ...). Also throws an exception if (count args) doesn't match
-  (count (:in query))."
+  (map first ...) after (vector ...)-ing the value. Also throws an exception if
+  (count args) doesn't match (count (:in query))."
   [db query & args]
   (apply bxt/q db query args))
 


### PR DESCRIPTION
Reading the initial doc, it wasn't altogether clear that the `:find` value is being specially handled if it isn't a vector... which it is. This patch clarifies that.

(NOTE: I'm guessing that the docs are probably auto-generated from the docstrings here, so I chose to update the docstring here, vs the docs for biffweb.com. If this is not the case, please feel free to let me know.)