### PR TITLE
fix(config.template.env): username in postgres jdbc should be user

### DIFF
--- a/starter/resources/config.template.env
+++ b/starter/resources/config.template.env
@@ -20,7 +20,7 @@ RECAPTCHA_SECRET_KEY=
 XTDB_TOPOLOGY=standalone
 # Uncomment these to use Postgres for storage in production:
 #PROD_XTDB_TOPOLOGY=jdbc
-#XTDB_JDBC_URL=jdbc:postgresql://host:port/dbname?username=alice&password=abc123
+#XTDB_JDBC_URL=jdbc:postgresql://host:port/dbname?user=alice&password=abc123
 
 # What port should the nrepl server be started on (in dev and prod)?
 NREPL_PORT=7888


### PR DESCRIPTION
The postgres JDBC driver (at least for PG 16) requires the username to be set using the user parameter.