### PR TITLE
fix: remove default-jre

### DIFF
--- a/starter/Dockerfile
+++ b/starter/Dockerfile
@@ -14,7 +14,7 @@ from clojure:temurin-17-tools-deps-bullseye
 ENV TAILWIND_VERSION=v3.2.4
 
 RUN apt-get update && apt-get install -y \
-  curl default-jre \
+  curl \
   && rm -rf /var/lib/apt/lists/*
 RUN curl -L -o /usr/local/bin/tailwindcss \
   https://github.com/tailwindlabs/tailwindcss/releases/download/$TAILWIND_VERSION/tailwindcss-linux-x64 \


### PR DESCRIPTION
The Docker base image (temurin-17) already has Java-17, the default-jre would also install Java 11. This reduces the image size from 1.2GB to 800MB.