### PR TITLE
fix(docker): use Java from the base image

### DIFF
--- a/starter/Dockerfile
+++ b/starter/Dockerfile
@@ -14,7 +14,7 @@ from clojure:temurin-17-tools-deps-bullseye
 ENV TAILWIND_VERSION=v3.2.4
 
 RUN apt-get update && apt-get install -y \
-  curl default-jre \
+  curl \
   && rm -rf /var/lib/apt/lists/*
 RUN curl -L -o /usr/local/bin/tailwindcss \
   https://github.com/tailwindlabs/tailwindcss/releases/download/$TAILWIND_VERSION/tailwindcss-linux-x64 \
@@ -34,4 +34,4 @@ EXPOSE 8080
 ENV BIFF_PROFILE=prod
 ENV HOST=0.0.0.0
 ENV PORT=8080
-CMD ["/usr/bin/java", "-XX:-OmitStackTraceInFastThrow", "-XX:+CrashOnOutOfMemoryError", "-jar", "app.jar"]
+CMD ["/opt/java/openjdk/bin/java", "-XX:-OmitStackTraceInFastThrow", "-XX:+CrashOnOutOfMemoryError", "-jar", "app.jar"]


### PR DESCRIPTION
After debugging the use of Java in the image I found that the temurin base image puts the openjdk and thus the java commands in a package specific path. Calling java with its absolute path requires the path of the package specific location instead of the commonly known java path. 

This replaces pull request #201 