### PR TITLE
fix(docker): implement multi-stage build

### DIFF
--- a/starter/Dockerfile
+++ b/starter/Dockerfile
@@ -11,7 +11,7 @@
 
 # This is the base builder image, construct the jar file in this one
 # it uses alpine for a small image
-FROM clojure:temurin-22-tools-deps-alpine AS jre-build
+FROM clojure:temurin-21-tools-deps-alpine AS jre-build
 
 ENV TAILWIND_VERSION=v3.2.4
 
@@ -31,7 +31,7 @@ RUN clj -M:dev uberjar && cp target/jar/app.jar . && rm -r target
 
 # This stage (see multi-stage builds) is a bare Java container
 # copy over the uberjar from the builder image and run the application
-FROM eclipse-temurin:22-alpine
+FROM eclipse-temurin:21-alpine
 WORKDIR /app
 
 # Take the uberjar from the base image and put it in the final image

--- a/starter/Dockerfile
+++ b/starter/Dockerfile
@@ -8,15 +8,15 @@
 #
 #   docker build -t your-app .
 #   docker run --rm -e BIFF_PROFILE=dev -v $PWD/config.env:/app/config.env your-app
-#
-FROM clojure:temurin-17-tools-deps-bullseye
+
+# This is the base builder image, construct the jar file in this one
+# it uses alpine for a small image
+FROM clojure:temurin-22-tools-deps-alpine AS jre-build
 
 ENV TAILWIND_VERSION=v3.2.4
 
-RUN apt-get update && apt-get install -y \
-  curl \
-  && rm -rf /var/lib/apt/lists/*
-RUN curl -L -o /usr/local/bin/tailwindcss \
+# Install the missing packages and applications in a single layer
+RUN apk add curl rlwrap && curl -L -o /usr/local/bin/tailwindcss \
   https://github.com/tailwindlabs/tailwindcss/releases/download/$TAILWIND_VERSION/tailwindcss-linux-x64 \
   && chmod +x /usr/local/bin/tailwindcss
 
@@ -26,11 +26,20 @@ COPY dev ./dev
 COPY resources ./resources
 COPY deps.edn .
 
+# construct the application jar
 RUN clj -M:dev uberjar && cp target/jar/app.jar . && rm -r target
-RUN rm -r /usr/local/bin/tailwindcss src dev resources deps.edn
+
+# This stage (see multi-stage builds) is a bare Java container
+# copy over the uberjar from the builder image and run the application
+FROM eclipse-temurin:22-alpine
+WORKDIR /app
+
+# Take the uberjar from the base image and put it in the final image
+COPY --from=jre-build /app/app.jar /app/app.jar
 
 EXPOSE 8080
 
+# By default, run in PROD profile
 ENV BIFF_PROFILE=prod
 ENV HOST=0.0.0.0
 ENV PORT=8080


### PR DESCRIPTION
Docker supports the concept of multi-stage builds. First you create layers that contain all the development tools and build tools that are required, then it takes the smallest possible image that can run the application. That smallest possible image is what is pushed to the registry.

Using this technique the image size becomes manageable, my results so far:

- 1.2GB original biff Dockerfile
- 832MB removing the default-jre
- 600MB moving to Alpine as a base image
- 452MB using multi-stage buildes

Additional size reduction is possible through graalvm's native-image, however I have not been able to build the biff starter with it.