### PR TITLE
starter/middleware.clj: prevent infinite loop between /app <-> /?error=not-signed-in if (:uid session) but user has been deleted

### DIFF
--- a/starter/src/com/example/middleware.clj
+++ b/starter/src/com/example/middleware.clj
@@ -16,7 +16,8 @@
     (if (some? (:uid session))
       (handler ctx)
       {:status 303
-       :headers {"location" "/signin?error=not-signed-in"}})))
+       :headers {"location" "/signin?error=not-signed-in"}
+       :session (dissoc session :uid)})))
 
 ;; Stick this function somewhere in your middleware stack below if you want to
 ;; inspect what things look like before/after certain middleware fns run.


### PR DESCRIPTION
this would happen in the case of say a dev db cleanup, or a user being removed in prod, etc.