### PR TITLE
Added --protocol=29 for rsync backwards compatibility

### DIFF
--- a/tasks/src/com/biffweb/tasks.clj
+++ b/tasks/src/com/biffweb/tasks.clj
@@ -332,7 +332,7 @@
         (fs/set-posix-file-permissions "config.env" "rw-------"))
       )
     (->> (concat ["rsync" "--archive" "--verbose" "--relative" "--include='**.gitignore'"
-                  "--exclude='/.git'" "--filter=:- .gitignore" "--delete-after"]
+                  "--exclude='/.git'" "--filter=:- .gitignore" "--delete-after" "--protocol=29"]
                  files
                  [(str "app@" server ":")])
          (apply shell))))


### PR DESCRIPTION
Adds push-files compatibility to Intel Macs.