### PR TITLE
Update nrepl dependencies to latest versions.

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:paths ["src"]
  :deps {better-cond/better-cond        {:mvn/version "2.1.4"}
         buddy/buddy-sign               {:mvn/version "3.4.333"}
-        cider/cider-nrepl              {:mvn/version "0.45.0"}
+        cider/cider-nrepl              {:mvn/version "0.51.1"}
         clj-http/clj-http              {:mvn/version "3.12.3"}
         com.nextjournal/beholder       {:mvn/version "1.0.2"}
         com.xtdb/xtdb-core             {:mvn/version "1.23.1"}
@@ -13,7 +13,7 @@
         metosin/malli                  {:mvn/version "0.16.1"}
         metosin/muuntaja               {:mvn/version "0.6.8"}
         metosin/reitit-ring            {:mvn/version "0.6.0"}
-        nrepl/nrepl                    {:mvn/version "1.0.0"}
+        nrepl/nrepl                    {:mvn/version "1.3.1"}
         org.clojure/tools.deps.alpha   {:git/url "https://github.com/clojure/tools.deps.alpha"
                                         :sha "8f8fc2571e721301b6d52e191129248355cb8c5a"}
         org.clojure/tools.logging      {:mvn/version "1.2.4"}


### PR DESCRIPTION
This fixes my problem with starting fresh project. Error was:

```
[chime-1] INFO my.example.worker - There are 0 users.
Execution error (IllegalArgumentException) at orchard.misc/require-and-resolve (misc.clj:161).
No such namespace: orchard.java.parser-utils
```

And it started to appear after I've upgraded Java on my system to:

```
openjdk 23 2024-09-17
OpenJDK Runtime Environment (build 23)
OpenJDK 64-Bit Server VM (build 23, mixed mode, sharing)
```

